### PR TITLE
Add .env files support

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,0 +1,1 @@
+NODE_ENV=development

--- a/.env.production
+++ b/.env.production
@@ -1,0 +1,1 @@
+NODE_ENV=production

--- a/.env.staging
+++ b/.env.staging
@@ -1,0 +1,1 @@
+NODE_ENV=development

--- a/build/tasks/bundle.js
+++ b/build/tasks/bundle.js
@@ -3,7 +3,7 @@ const browserifyinc = require('browserify-incremental')
 const buffer = require('vinyl-buffer')
 const cssModulesify = require('css-modulesify')
 const cssNext = require('postcss-cssnext')
-const envify = require('envify/custom')
+const envify = require('envify')
 const es3ify = require('es3ify')
 const gulp = require('gulp')
 const gutil = require('gulp-util')
@@ -33,9 +33,7 @@ const clientBundler = browserifyinc(Object.assign({}, BROWSERIFY_OPTS, {
   cache: {},
   packageCache: {},
 }))
-clientBundler.transform(envify({
-  NODE_ENV: process.env.NODE_ENV
-}))
+clientBundler.transform(envify)
 clientBundler.plugin(cssModulesify, CSS_MODULES_OPTS)
 
 const serverBundler = browserifyinc(Object.assign({}, BROWSERIFY_OPTS, {

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,1 +1,8 @@
+const env = require('node-env-file')
+const path = require('path')
+
+if (process.env.ENV_FILE) {
+  env(path.join(process.cwd(), process.env.ENV_FILE))
+}
+
 require('./build/tasks')

--- a/package.json
+++ b/package.json
@@ -12,9 +12,9 @@
   },
   "scripts": {
     "build:setup": "rm -rf .dev/* dist/* && mkdir -p dist .dev",
-    "build:prod": "npm run build:setup && NODE_ENV=production gulp build",
-    "build:staging": "npm run build:setup && NODE_ENV=staging gulp build",
-    "dev": "gulp dev",
+    "build:prod": "npm run build:setup && ENV_FILE=.env.production gulp build",
+    "build:staging": "npm run build:setup && ENV_FILE=.env.staging gulp build",
+    "dev": "ENV_FILE=.env.development gulp dev",
     "lint": "standard",
     "test": "npm run lint && mocha --compilers js:babel-register,css:css-modules-require-hook --recursive source/**/__tests__/*-test.js",
     "deploy:staging": "npm run build:staging && gh-pages -d dist"
@@ -71,6 +71,7 @@
     "mkdirp": "^0.5.1",
     "mocha": "^2.3.4",
     "mocha-jsdom": "^1.0.0",
+    "node-env-file": "^0.1.8",
     "node-static": "^0.7.7",
     "nodemon": "^1.8.1",
     "postcss-cssnext": "^2.4.0",


### PR DESCRIPTION
Easiest to describe the use case here:

In development and staging, we might want to use everydayhero-staging when using edh-widgets, along with a Campaign UID, Charity UID, etc. specific to these environments, then automatically switch over to use different values when building for production.
